### PR TITLE
Update_cache on fresh VM, avoids massive failure during installation with apt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Ensure Tomcat6 is installed (Debian).
-  apt: name=tomcat6 state=installed
+  apt: name=tomcat6 state=installed update_cache=yes
   when: ansible_os_family == 'Debian'
 
 - name: Copy tomcat6 server.xml.


### PR DESCRIPTION
For instance:

```
TASK: [tomcat6 | Ensure Tomcat6 is installed (Debian).] ***********************
failed: [default] => {"failed": true}
stderr: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-7/openjdk-7-jre-headless_7u55-2.4.7-1ubuntu1_amd64.deb  404  Not Found [IP: 91.189.88.153 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-7/icedtea-7-jre-jamvm_7u55-2.4.7-1ubuntu1_amd64.deb  404  Not Found [IP: 91.189.88.153 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

stdout: Reading package lists...
Building dependency tree...
```

Instantiated with: https://github.com/brainstorm/ansible-xnat
